### PR TITLE
preventing ci to run release step on prs

### DIFF
--- a/.github/workflows/packaging-helm-chart.yaml
+++ b/.github/workflows/packaging-helm-chart.yaml
@@ -55,6 +55,7 @@ jobs:
 
   release:
     needs: lint-test
+    if: github.ref == 'refs/heads/main'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
This PR prevents CI job 'release' to run in PRs